### PR TITLE
Update minimum rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/wkb"
 description = "Standalone WKB reader and writer"
 categories = ["science::geo"]
-# Note: this can be relaxed; I haven't kept track of what I've used.
-rust-version = "1.80"
+# 1.82 is the minimum version for `impl GeometryTrait + use<'_>` in `read_wkb`
+# https://rust-lang.github.io/rfcs/3617-precise-capturing.html
+rust-version = "1.82"
 
 [dependencies]
 byteorder = "1"


### PR DESCRIPTION
It turns out that the minimum rust version is actually 1.82 (given the `use<'_>` syntax in `read_wkb`)

Check with:
```
rustup install 1.81.0
rustup run 1.81.0 cargo build
```

gives:
```
error[E0658]: precise captures on `impl Trait` are experimental
  --> src/reader/mod.rs:33:63
   |
33 | pub fn read_wkb(buf: &[u8]) -> WKBResult<impl GeometryTrait + use<'_>> {
   |                                                               ^^^
   |
   = note: see issue #123432 <https://github.com/rust-lang/rust/issues/123432> for more information
```