### PR TITLE
Return f64 geometry

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -31,6 +31,6 @@ use geo_traits::GeometryTrait;
 
 use crate::error::WKBResult;
 
-pub fn read_wkb(buf: &[u8]) -> WKBResult<impl GeometryTrait + use<'_>> {
+pub fn read_wkb(buf: &[u8]) -> WKBResult<impl GeometryTrait<T = f64> + use<'_>> {
     Wkb::try_new(buf)
 }


### PR DESCRIPTION
Edit the return type of `read_wkb` to indicate that the returned geometry has type `T=f64`.