### PR TITLE
Inline trait bound for writer

### DIFF
--- a/src/writer/coord.rs
+++ b/src/writer/coord.rs
@@ -6,8 +6,8 @@ use geo_traits::CoordTrait;
 use crate::error::WKBResult;
 
 /// Write a coordinate to a Writer encoded as WKB
-pub(crate) fn write_coord<W: Write, B: ByteOrder>(
-    writer: &mut W,
+pub(crate) fn write_coord<B: ByteOrder>(
+    writer: &mut impl Write,
     coord: &impl CoordTrait<T = f64>,
 ) -> WKBResult<()> {
     for i in 0..coord.dim().size() {

--- a/src/writer/geometry.rs
+++ b/src/writer/geometry.rs
@@ -27,8 +27,8 @@ pub fn geometry_wkb_size(geom: &impl GeometryTrait) -> usize {
 }
 
 /// Write a Geometry to a Writer encoded as WKB
-pub fn write_geometry<W: Write>(
-    writer: &mut W,
+pub fn write_geometry(
+    writer: &mut impl Write,
     geom: &impl GeometryTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {

--- a/src/writer/geometrycollection.rs
+++ b/src/writer/geometrycollection.rs
@@ -18,8 +18,8 @@ pub fn geometry_collection_wkb_size(geom: &impl GeometryCollectionTrait) -> usiz
 }
 
 /// Write a GeometryCollection geometry to a Writer encoded as WKB
-pub fn write_geometry_collection<W: Write>(
-    writer: &mut W,
+pub fn write_geometry_collection(
+    writer: &mut impl Write,
     geom: &impl GeometryCollectionTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -29,16 +29,16 @@ pub fn write_geometry_collection<W: Write>(
     // Content
     match endianness {
         Endianness::LittleEndian => {
-            write_geometry_collection_content::<W, LittleEndian>(writer, geom, endianness)
+            write_geometry_collection_content::<LittleEndian>(writer, geom, endianness)
         }
         Endianness::BigEndian => {
-            write_geometry_collection_content::<W, BigEndian>(writer, geom, endianness)
+            write_geometry_collection_content::<BigEndian>(writer, geom, endianness)
         }
     }
 }
 
-fn write_geometry_collection_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_geometry_collection_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl GeometryCollectionTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {

--- a/src/writer/linestring.rs
+++ b/src/writer/linestring.rs
@@ -15,8 +15,8 @@ pub fn line_string_wkb_size(geom: &impl LineStringTrait) -> usize {
 }
 
 /// Write a LineString geometry to a Writer encoded as WKB
-pub fn write_line_string<W: Write>(
-    writer: &mut W,
+pub fn write_line_string(
+    writer: &mut impl Write,
     geom: &impl LineStringTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -25,13 +25,13 @@ pub fn write_line_string<W: Write>(
 
     // Content
     match endianness {
-        Endianness::LittleEndian => write_line_string_content::<W, LittleEndian>(writer, geom),
-        Endianness::BigEndian => write_line_string_content::<W, BigEndian>(writer, geom),
+        Endianness::LittleEndian => write_line_string_content::<LittleEndian>(writer, geom),
+        Endianness::BigEndian => write_line_string_content::<BigEndian>(writer, geom),
     }
 }
 
-fn write_line_string_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_line_string_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl LineStringTrait<T = f64>,
 ) -> WKBResult<()> {
     let wkb_type = WKBType::LineString(geom.dim().try_into()?);
@@ -43,7 +43,7 @@ fn write_line_string_content<W: Write, B: ByteOrder>(
         .unwrap();
 
     for coord in geom.coords() {
-        write_coord::<W, B>(writer, &coord)?;
+        write_coord::<B>(writer, &coord)?;
     }
 
     Ok(())

--- a/src/writer/multilinestring.rs
+++ b/src/writer/multilinestring.rs
@@ -17,8 +17,8 @@ pub fn multi_line_string_wkb_size(geom: &impl MultiLineStringTrait) -> usize {
 }
 
 /// Write a MultiLineString geometry to a Writer encoded as WKB
-pub fn write_multi_line_string<W: Write>(
-    writer: &mut W,
+pub fn write_multi_line_string(
+    writer: &mut impl Write,
     geom: &impl MultiLineStringTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -28,16 +28,16 @@ pub fn write_multi_line_string<W: Write>(
     // Content
     match endianness {
         Endianness::LittleEndian => {
-            write_multi_line_string_content::<W, LittleEndian>(writer, geom, endianness)
+            write_multi_line_string_content::<LittleEndian>(writer, geom, endianness)
         }
         Endianness::BigEndian => {
-            write_multi_line_string_content::<W, BigEndian>(writer, geom, endianness)
+            write_multi_line_string_content::<BigEndian>(writer, geom, endianness)
         }
     }
 }
 
-fn write_multi_line_string_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_multi_line_string_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl MultiLineStringTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {

--- a/src/writer/multipoint.rs
+++ b/src/writer/multipoint.rs
@@ -12,8 +12,8 @@ pub fn multi_point_wkb_size(geom: &impl MultiPointTrait) -> usize {
 }
 
 /// Write a MultiPoint geometry to a Writer encoded as WKB
-pub fn write_multi_point<W: Write>(
-    writer: &mut W,
+pub fn write_multi_point(
+    writer: &mut impl Write,
     geom: &impl MultiPointTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -23,16 +23,14 @@ pub fn write_multi_point<W: Write>(
     // Content
     match endianness {
         Endianness::LittleEndian => {
-            write_multi_point_content::<W, LittleEndian>(writer, geom, endianness)
+            write_multi_point_content::<LittleEndian>(writer, geom, endianness)
         }
-        Endianness::BigEndian => {
-            write_multi_point_content::<W, BigEndian>(writer, geom, endianness)
-        }
+        Endianness::BigEndian => write_multi_point_content::<BigEndian>(writer, geom, endianness),
     }
 }
 
-fn write_multi_point_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_multi_point_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl MultiPointTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {

--- a/src/writer/multipolygon.rs
+++ b/src/writer/multipolygon.rs
@@ -17,8 +17,8 @@ pub fn multi_polygon_wkb_size(geom: &impl MultiPolygonTrait) -> usize {
 }
 
 /// Write a MultiPolygon geometry to a Writer encoded as WKB
-pub fn write_multi_polygon<W: Write>(
-    writer: &mut W,
+pub fn write_multi_polygon(
+    writer: &mut impl Write,
     geom: &impl MultiPolygonTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -28,16 +28,14 @@ pub fn write_multi_polygon<W: Write>(
     // Content
     match endianness {
         Endianness::LittleEndian => {
-            write_multi_polygon_content::<W, LittleEndian>(writer, geom, endianness)
+            write_multi_polygon_content::<LittleEndian>(writer, geom, endianness)
         }
-        Endianness::BigEndian => {
-            write_multi_polygon_content::<W, BigEndian>(writer, geom, endianness)
-        }
+        Endianness::BigEndian => write_multi_polygon_content::<BigEndian>(writer, geom, endianness),
     }
 }
 
-fn write_multi_polygon_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_multi_polygon_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl MultiPolygonTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {

--- a/src/writer/point.rs
+++ b/src/writer/point.rs
@@ -15,8 +15,8 @@ pub fn point_wkb_size(dim: geo_traits::Dimensions) -> usize {
 }
 
 /// Write a Point geometry to a Writer encoded as WKB
-pub fn write_point<W: Write>(
-    writer: &mut W,
+pub fn write_point(
+    writer: &mut impl Write,
     geom: &impl PointTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -25,21 +25,21 @@ pub fn write_point<W: Write>(
 
     // Content
     match endianness {
-        Endianness::LittleEndian => write_point_content::<W, LittleEndian>(writer, geom),
-        Endianness::BigEndian => write_point_content::<W, BigEndian>(writer, geom),
+        Endianness::LittleEndian => write_point_content::<LittleEndian>(writer, geom),
+        Endianness::BigEndian => write_point_content::<BigEndian>(writer, geom),
     }
 }
 
 /// Write a Point geometry to a Writer encoded as WKB
-fn write_point_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_point_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl PointTrait<T = f64>,
 ) -> WKBResult<()> {
     let wkb_type = WKBType::Point(geom.dim().try_into()?);
     writer.write_u32::<LittleEndian>(wkb_type.into())?;
 
     if let Some(coord) = geom.coord() {
-        write_coord::<W, B>(writer, &coord)?;
+        write_coord::<B>(writer, &coord)?;
     } else {
         // Write POINT EMPTY as f64::NAN values
         for _ in 0..geom.dim().size() {

--- a/src/writer/polygon.rs
+++ b/src/writer/polygon.rs
@@ -24,8 +24,8 @@ pub fn polygon_wkb_size(geom: &impl PolygonTrait) -> usize {
 }
 
 /// Write a Polygon geometry to a Writer encoded as WKB
-pub fn write_polygon<W: Write>(
-    writer: &mut W,
+pub fn write_polygon(
+    writer: &mut impl Write,
     geom: &impl PolygonTrait<T = f64>,
     endianness: Endianness,
 ) -> WKBResult<()> {
@@ -34,13 +34,13 @@ pub fn write_polygon<W: Write>(
 
     // Content
     match endianness {
-        Endianness::LittleEndian => write_polygon_content::<W, LittleEndian>(writer, geom),
-        Endianness::BigEndian => write_polygon_content::<W, BigEndian>(writer, geom),
+        Endianness::LittleEndian => write_polygon_content::<LittleEndian>(writer, geom),
+        Endianness::BigEndian => write_polygon_content::<BigEndian>(writer, geom),
     }
 }
 
-fn write_polygon_content<W: Write, B: ByteOrder>(
-    writer: &mut W,
+fn write_polygon_content<B: ByteOrder>(
+    writer: &mut impl Write,
     geom: &impl PolygonTrait<T = f64>,
 ) -> WKBResult<()> {
     let wkb_type = WKBType::Polygon(geom.dim().try_into()?);
@@ -58,7 +58,7 @@ fn write_polygon_content<W: Write, B: ByteOrder>(
         writer.write_u32::<B>(ext_ring.num_coords().try_into().unwrap())?;
 
         for coord in ext_ring.coords() {
-            write_coord::<W, B>(writer, &coord)?;
+            write_coord::<B>(writer, &coord)?;
         }
     }
 
@@ -66,7 +66,7 @@ fn write_polygon_content<W: Write, B: ByteOrder>(
         writer.write_u32::<B>(int_ring.num_coords().try_into().unwrap())?;
 
         for coord in int_ring.coords() {
-            write_coord::<W, B>(writer, &coord)?;
+            write_coord::<B>(writer, &coord)?;
         }
     }
 


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [ ] I ran cargo fmt
---

Use `&mut impl Write` instead of adding a new `W: Write` generic