### PR TITLE
Add support for writing Line and Triangle geometries

### DIFF
--- a/src/writer/geometry.rs
+++ b/src/writer/geometry.rs
@@ -1,16 +1,17 @@
 use crate::error::WKBResult;
 use crate::writer::{
-    geometry_collection_wkb_size, line_string_wkb_size, multi_line_string_wkb_size,
+    geometry_collection_wkb_size, line_string_wkb_size, line_wkb_size, multi_line_string_wkb_size,
     multi_point_wkb_size, multi_polygon_wkb_size, point_wkb_size, polygon_wkb_size,
-    write_geometry_collection, write_line_string, write_multi_line_string, write_multi_point,
-    write_multi_polygon, write_point, write_polygon,
+    triangle_wkb_size, write_geometry_collection, write_line, write_line_string,
+    write_multi_line_string, write_multi_point, write_multi_polygon, write_point, write_polygon,
+    write_triangle,
 };
 use crate::Endianness;
 use geo_traits::{GeometryTrait, GeometryType};
 use std::io::Write;
 
 /// The byte length of a Geometry
-pub fn geometry_wkb_size(geom: &impl GeometryTrait) -> usize {
+pub fn geometry_wkb_size(geom: &impl GeometryTrait<T = f64>) -> usize {
     use GeometryType::*;
     match geom.as_type() {
         Point(_) => point_wkb_size(geom.dim()),
@@ -21,8 +22,8 @@ pub fn geometry_wkb_size(geom: &impl GeometryTrait) -> usize {
         MultiPolygon(mp) => multi_polygon_wkb_size(mp),
         GeometryCollection(gc) => geometry_collection_wkb_size(gc),
         Rect(_) => todo!(),
-        Triangle(_) => todo!(),
-        Line(_) => todo!(),
+        Triangle(tri) => triangle_wkb_size(tri),
+        Line(line) => line_wkb_size(line),
     }
 }
 
@@ -42,7 +43,7 @@ pub fn write_geometry<W: Write>(
         MultiPolygon(mp) => write_multi_polygon(writer, mp, endianness),
         GeometryCollection(gc) => write_geometry_collection(writer, gc, endianness),
         Rect(_) => todo!(),
-        Triangle(_) => todo!(),
-        Line(_) => todo!(),
+        Triangle(tri) => write_triangle(writer, tri, endianness),
+        Line(line) => write_line(writer, line, endianness),
     }
 }

--- a/src/writer/geometrycollection.rs
+++ b/src/writer/geometrycollection.rs
@@ -7,7 +7,7 @@ use geo_traits::GeometryCollectionTrait;
 use std::io::Write;
 
 /// The byte length of a GeometryCollection
-pub fn geometry_collection_wkb_size(geom: &impl GeometryCollectionTrait) -> usize {
+pub fn geometry_collection_wkb_size(geom: &impl GeometryCollectionTrait<T = f64>) -> usize {
     let mut sum = 1 + 4 + 4;
 
     for inner_geom in geom.geometries() {

--- a/src/writer/line.rs
+++ b/src/writer/line.rs
@@ -1,0 +1,45 @@
+use std::io::Write;
+
+use geo_traits::{LineStringTrait, LineTrait};
+
+use crate::error::WKBResult;
+use crate::writer::{line_string_wkb_size, write_line_string};
+use crate::Endianness;
+
+/// A wrapper around an impl LineTrait to provide LineStringTrait
+struct LineWrapper<'a, G: LineTrait<T = f64>>(&'a G);
+
+impl<'a, G: LineTrait<T = f64>> LineStringTrait for LineWrapper<'a, G> {
+    type T = f64;
+    type CoordType<'b> = G::CoordType<'a> where G: 'b, Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.0.dim()
+    }
+
+    fn num_coords(&self) -> usize {
+        2
+    }
+
+    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
+        match i {
+            0 => self.0.start(),
+            1 => self.0.end(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// The byte length of a Line
+pub fn line_wkb_size(geom: &impl LineTrait<T = f64>) -> usize {
+    line_string_wkb_size(&LineWrapper(geom))
+}
+
+/// Write a Line geometry to a Writer encoded as WKB
+pub fn write_line(
+    writer: &mut impl Write,
+    geom: &impl LineTrait<T = f64>,
+    endianness: Endianness,
+) -> WKBResult<()> {
+    write_line_string(writer, &LineWrapper(geom), endianness)
+}

--- a/src/writer/linestring.rs
+++ b/src/writer/linestring.rs
@@ -7,7 +7,7 @@ use geo_traits::LineStringTrait;
 use std::io::Write;
 
 /// The byte length of a LineString
-pub fn line_string_wkb_size(geom: &impl LineStringTrait) -> usize {
+pub fn line_string_wkb_size(geom: &impl LineStringTrait<T = f64>) -> usize {
     let header = 1 + 4 + 4;
     let each_coord = geom.dim().size() * 8;
     let all_coords = geom.num_coords() * each_coord;

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -1,18 +1,22 @@
 mod coord;
 mod geometry;
 mod geometrycollection;
+mod line;
 mod linestring;
 mod multilinestring;
 mod multipoint;
 mod multipolygon;
 mod point;
 mod polygon;
+mod triangle;
 
 pub use geometry::{geometry_wkb_size, write_geometry};
 pub use geometrycollection::{geometry_collection_wkb_size, write_geometry_collection};
+pub use line::{line_wkb_size, write_line};
 pub use linestring::{line_string_wkb_size, write_line_string};
 pub use multilinestring::{multi_line_string_wkb_size, write_multi_line_string};
 pub use multipoint::{multi_point_wkb_size, write_multi_point};
 pub use multipolygon::{multi_polygon_wkb_size, write_multi_polygon};
 pub use point::{point_wkb_size, write_point};
 pub use polygon::{polygon_wkb_size, write_polygon};
+pub use triangle::{triangle_wkb_size, write_triangle};

--- a/src/writer/multilinestring.rs
+++ b/src/writer/multilinestring.rs
@@ -7,7 +7,7 @@ use geo_traits::MultiLineStringTrait;
 use std::io::Write;
 
 /// The byte length of a MultiLineString
-pub fn multi_line_string_wkb_size(geom: &impl MultiLineStringTrait) -> usize {
+pub fn multi_line_string_wkb_size(geom: &impl MultiLineStringTrait<T = f64>) -> usize {
     let mut sum = 1 + 4 + 4;
     for line_string in geom.line_strings() {
         sum += line_string_wkb_size(&line_string);

--- a/src/writer/multipoint.rs
+++ b/src/writer/multipoint.rs
@@ -7,7 +7,7 @@ use geo_traits::MultiPointTrait;
 use std::io::Write;
 
 /// The byte length of a MultiPoint
-pub fn multi_point_wkb_size(geom: &impl MultiPointTrait) -> usize {
+pub fn multi_point_wkb_size(geom: &impl MultiPointTrait<T = f64>) -> usize {
     1 + 4 + 4 + (geom.num_points() * point_wkb_size(geom.dim()))
 }
 

--- a/src/writer/multipolygon.rs
+++ b/src/writer/multipolygon.rs
@@ -7,7 +7,7 @@ use geo_traits::MultiPolygonTrait;
 use std::io::Write;
 
 /// The byte length of a MultiPolygon
-pub fn multi_polygon_wkb_size(geom: &impl MultiPolygonTrait) -> usize {
+pub fn multi_polygon_wkb_size(geom: &impl MultiPolygonTrait<T = f64>) -> usize {
     let mut sum = 1 + 4 + 4;
     for polygon in geom.polygons() {
         sum += polygon_wkb_size(&polygon);

--- a/src/writer/polygon.rs
+++ b/src/writer/polygon.rs
@@ -7,7 +7,7 @@ use geo_traits::{LineStringTrait, PolygonTrait};
 use std::io::Write;
 
 /// The byte length of a Polygon
-pub fn polygon_wkb_size(geom: &impl PolygonTrait) -> usize {
+pub fn polygon_wkb_size(geom: &impl PolygonTrait<T = f64>) -> usize {
     let mut sum = 1 + 4 + 4;
 
     let each_coord = geom.dim().size() * 8;

--- a/src/writer/triangle.rs
+++ b/src/writer/triangle.rs
@@ -1,0 +1,67 @@
+use std::io::Write;
+
+use geo_traits::{LineStringTrait, PolygonTrait, TriangleTrait};
+
+use crate::error::WKBResult;
+use crate::writer::{polygon_wkb_size, write_polygon};
+use crate::Endianness;
+
+/// A wrapper around an impl TriangleTrait to provide LineStringTrait and PolygonTrait
+struct TriangleWrapper<'a, G: TriangleTrait<T = f64>>(&'a G);
+
+impl<'a, G: TriangleTrait<T = f64>> LineStringTrait for &'a TriangleWrapper<'a, G> {
+    type T = f64;
+    type CoordType<'b> = G::CoordType<'a> where G: 'b, Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.0.dim()
+    }
+
+    fn num_coords(&self) -> usize {
+        3
+    }
+
+    unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
+        match i {
+            0 => self.0.first(),
+            1 => self.0.second(),
+            2 => self.0.third(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a, G: TriangleTrait<T = f64>> PolygonTrait for TriangleWrapper<'a, G> {
+    type T = f64;
+    type RingType<'b> = &'b TriangleWrapper<'b, G> where G: 'b, Self: 'b;
+
+    fn dim(&self) -> geo_traits::Dimensions {
+        self.0.dim()
+    }
+
+    fn exterior(&self) -> Option<Self::RingType<'_>> {
+        Some(self)
+    }
+
+    fn num_interiors(&self) -> usize {
+        0
+    }
+
+    unsafe fn interior_unchecked(&self, _i: usize) -> Self::RingType<'_> {
+        unreachable!()
+    }
+}
+
+/// The byte length of a Triangle
+pub fn triangle_wkb_size(geom: &impl TriangleTrait<T = f64>) -> usize {
+    polygon_wkb_size(&TriangleWrapper(geom))
+}
+
+/// Write a Triangle geometry to a Writer encoded as WKB
+pub fn write_triangle(
+    writer: &mut impl Write,
+    geom: &impl TriangleTrait<T = f64>,
+    endianness: Endianness,
+) -> WKBResult<()> {
+    write_polygon(writer, &TriangleWrapper(geom), endianness)
+}


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [ ] I ran cargo fmt
---

These are written to WKB as LineString and Polygon, respectively.