### PR TITLE
Add benches w/ copy to geo geometry & encoding

### DIFF
--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use criterion::{criterion_group, criterion_main};
+use geo_traits::to_geo::ToGeoGeometry;
 use wkt::Wkt;
 
 fn load_small_wkt() -> Wkt<f64> {
@@ -34,6 +35,20 @@ fn bench_parse(c: &mut criterion::Criterion) {
     c.bench_function("parse big", |bencher| {
         bencher.iter(|| {
             let _ = wkb::reader::read_wkb(&big_wkb).unwrap();
+        });
+    });
+
+    c.bench_function("parse small to geo", |bencher| {
+        bencher.iter(|| {
+            let wkb_geom = wkb::reader::read_wkb(&small_wkb).unwrap();
+            let _geo_types_geom = wkb_geom.to_geometry();
+        });
+    });
+
+    c.bench_function("parse big to geo", |bencher| {
+        bencher.iter(|| {
+            let wkb_geom = wkb::reader::read_wkb(&big_wkb).unwrap();
+            let _geo_types_geom = wkb_geom.to_geometry();
         });
     });
 }

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -51,6 +51,20 @@ fn bench_parse(c: &mut criterion::Criterion) {
             let _geo_types_geom = wkb_geom.to_geometry();
         });
     });
+
+    c.bench_function("encode small", |bencher| {
+        bencher.iter(|| {
+            let mut buf = Vec::new();
+            wkb::writer::write_geometry(&mut buf, &small, Default::default()).unwrap();
+        });
+    });
+
+    c.bench_function("encode big", |bencher| {
+        bencher.iter(|| {
+            let mut buf = Vec::new();
+            wkb::writer::write_geometry(&mut buf, &big, Default::default()).unwrap();
+        });
+    });
 }
 
 criterion_group!(benches, bench_parse);


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [ ] I ran cargo fmt
---

Previously the bench to parse was 

This is **2.3x faster** than `shapely.wkb.loads`, and 11x faster than `shapely.wkb.dumps`! There's probably a tiny bit of Python overhead on the shapely side (e.g. an extra full-buffer copy back to Python after GEOS has serialized the geometry to a buffer) but I expect this is still at least a little faster than GEOS.


```
parse big to geo        time:   [161.29 µs 161.83 µs 162.38 µs]
                        change: [-1.0724% -0.4549% +0.1358%] (p = 0.15 > 0.05)

encode big              time:   [49.969 µs 50.204 µs 50.437 µs]
```

```py
from shapely import wkt, wkb

with open('big.wkt') as f:
    geom = wkt.load(f)

%timeit buf = wkb.dumps(geom)
# 547 μs ± 3.2 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

%timeit test = wkb.loads(buf)
# 369 μs ± 1.01 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
