### PR TITLE
Add some function inlining

### DIFF
--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -49,18 +49,21 @@ impl<'a> Coord<'a> {
         }
     }
 
+    #[inline]
     fn get_x(&self) -> f64 {
         let mut reader = Cursor::new(self.buf);
         reader.set_position(self.offset);
         reader.read_f64(self.byte_order).unwrap()
     }
 
+    #[inline]
     fn get_y(&self) -> f64 {
         let mut reader = Cursor::new(self.buf);
         reader.set_position(self.offset + F64_WIDTH);
         reader.read_f64(self.byte_order).unwrap()
     }
 
+    #[inline]
     fn get_nth_unchecked(&self, n: usize) -> f64 {
         debug_assert!(n < self.dim.size());
         let mut reader = Cursor::new(self.buf);
@@ -84,14 +87,17 @@ impl<'a> CoordTrait for Coord<'a> {
         self.dim.into()
     }
 
+    #[inline]
     fn nth_or_panic(&self, n: usize) -> Self::T {
         self.get_nth_unchecked(n)
     }
 
+    #[inline]
     fn x(&self) -> Self::T {
         self.get_x()
     }
 
+    #[inline]
     fn y(&self) -> Self::T {
         self.get_y()
     }

--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -59,6 +59,7 @@ impl<'a> WKBLinearRing<'a> {
     }
 
     /// The offset into this buffer of any given coordinate
+    #[inline]
     pub fn coord_offset(&self, i: u64) -> u64 {
         self.offset + 4 + (self.dim.size() as u64 * 8 * i)
     }
@@ -72,10 +73,12 @@ impl<'a> LineStringTrait for WKBLinearRing<'a> {
         self.dim.into()
     }
 
+    #[inline]
     fn num_coords(&self) -> usize {
         self.num_points
     }
 
+    #[inline]
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
         Coord::new(
             self.buf,

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -57,10 +57,6 @@ impl<'a> Polygon<'a> {
             .fold(1 + 4 + 4, |acc, ring| acc + ring.size())
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.wkb_linear_rings.len() == 0
-    }
-
     pub fn dimension(&self) -> WKBDimension {
         self.dim
     }


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [ ] I ran cargo fmt
---

It turns out function inlining can have a surprisingly big effect on the benchmark:

```
Benchmarking parse small to geo: Collecting 100 samples in estimated 5.0001 s (42M itera
parse small to geo      time:   [125.30 ns 125.89 ns 126.34 ns]
                        change: [-12.615% -11.585% -10.646%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking parse big to geo: Collecting 100 samples in estimated 5.2794 s (40k iterati
parse big to geo        time:   [130.44 µs 131.96 µs 133.69 µs]
                        change: [-16.388% -15.530% -14.647%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  16 (16.00%) low mild
  2 (2.00%) high severe
```

That brings the parse to 2.8x faster than `shapely.wkb.loads` (see #37)