### PR TITLE
fix: Making `Wkb::buf()` return slices containing only the WKB and trim the trailing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Expose APIs for accessing the underlying WKB buffer. (#85)
+- Expose APIs for accessing the underlying WKB buffer. (#85, #88)
 - Making structs for individual geometry types public. (#85)
 
 ## 0.9.1 - 2025-09-24

--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -23,23 +23,14 @@ pub struct Coord<'a> {
     /// The byte order of this WKB buffer
     byte_order: Endianness,
 
-    /// The offset into the buffer where this coordinate is located
-    ///
-    /// Note that this does not have to be immediately after the WKB header! For a `Point`, the
-    /// `Point` is immediately after the header, but the `Point` also appears in other geometry
-    /// types. I.e. the `LineString` has a header, then the number of points, then a sequence of
-    /// `Point` objects.
-    offset: u64,
-
     dim: Dimension,
 }
 
 impl<'a> Coord<'a> {
-    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: Dimension) -> Self {
+    pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
         Self {
             buf,
             byte_order,
-            offset,
             dim,
         }
     }
@@ -47,14 +38,13 @@ impl<'a> Coord<'a> {
     #[inline]
     fn get_x(&self) -> f64 {
         let mut reader = Cursor::new(self.buf);
-        reader.set_position(self.offset);
         reader.read_f64(self.byte_order).unwrap()
     }
 
     #[inline]
     fn get_y(&self) -> f64 {
         let mut reader = Cursor::new(self.buf);
-        reader.set_position(self.offset + F64_WIDTH);
+        reader.set_position(F64_WIDTH);
         reader.read_f64(self.byte_order).unwrap()
     }
 
@@ -62,7 +52,7 @@ impl<'a> Coord<'a> {
     fn get_nth_unchecked(&self, n: usize) -> f64 {
         debug_assert!(n < self.dim.size());
         let mut reader = Cursor::new(self.buf);
-        reader.set_position(self.offset + (n as u64 * F64_WIDTH));
+        reader.set_position(n as u64 * F64_WIDTH);
         reader.read_f64(self.byte_order).unwrap()
     }
 
@@ -76,9 +66,8 @@ impl<'a> Coord<'a> {
     /// of coordinate can be obtained by calling [Coord::byte_order].
     #[inline]
     pub fn coord_slice(&self) -> &'a [u8] {
-        let start = self.offset as usize;
-        let end = start + self.size() as usize;
-        &self.buf[start..end]
+        let end = self.size() as usize;
+        &self.buf[0..end]
     }
 
     /// Get the dimension of this coordinate
@@ -88,8 +77,7 @@ impl<'a> Coord<'a> {
     }
 
     /// The number of bytes in this object
-    ///
-    /// Note that this is not the same as the length of the underlying buffer
+    #[inline]
     pub fn size(&self) -> u64 {
         // A 2D Coord is just two f64s
         self.dim.size() as u64 * 8

--- a/src/reader/coord.rs
+++ b/src/reader/coord.rs
@@ -17,7 +17,7 @@ const F64_WIDTH: u64 = 8;
 /// See page 65 of <https://portal.ogc.org/files/?artifact_id=25355>.
 #[derive(Debug, Clone, Copy)]
 pub struct Coord<'a> {
-    /// The underlying WKB buffer
+    /// The underlying WKB buffer. This should only contain the bytes for one coordinate.
     buf: &'a [u8],
 
     /// The byte order of this WKB buffer
@@ -29,7 +29,7 @@ pub struct Coord<'a> {
 impl<'a> Coord<'a> {
     pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: Dimension) -> Self {
         Self {
-            buf,
+            buf: &buf[..dim.size() * F64_WIDTH as usize],
             byte_order,
             dim,
         }
@@ -79,8 +79,7 @@ impl<'a> Coord<'a> {
     /// The number of bytes in this object
     #[inline]
     pub fn size(&self) -> u64 {
-        // A 2D Coord is just two f64s
-        self.dim.size() as u64 * 8
+        self.buf.len() as u64
     }
 }
 

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -58,3 +58,6 @@ pub enum GeometryType {
     /// A WKB GeometryCollection
     GeometryCollection,
 }
+
+/// skip endianness and wkb type
+const HEADER_BYTES: u64 = 5;

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -4,6 +4,7 @@ use crate::common::Dimension;
 use crate::error::{WkbError, WkbResult};
 use crate::reader::point::Point;
 use crate::reader::util::{has_srid, ReadBytesExt};
+use crate::reader::HEADER_BYTES;
 use crate::Endianness;
 use geo_traits::MultiPointTrait;
 
@@ -17,8 +18,11 @@ pub struct MultiPoint<'a> {
 
     /// The number of points in this multi point
     num_points: usize,
+
+    /// The offset into the buffer where the first point is located
+    points_offset: u64,
+
     dim: Dimension,
-    has_srid: bool,
 }
 
 impl<'a> MultiPoint<'a> {
@@ -27,32 +31,32 @@ impl<'a> MultiPoint<'a> {
         byte_order: Endianness,
         dim: Dimension,
     ) -> WkbResult<Self> {
-        let mut offset = 0;
-        let has_srid = has_srid(buf, byte_order, offset)?;
-        if has_srid {
-            offset += 4;
-        }
+        let has_srid = has_srid(buf, byte_order)?;
+        let num_points_offset = HEADER_BYTES + if has_srid { 4 } else { 0 };
 
         let mut reader = Cursor::new(buf);
         // Set reader to after 1-byte byteOrder and 4-byte wkbType
-        reader.set_position(1 + 4 + offset);
+        reader.set_position(num_points_offset);
         let num_points = reader
             .read_u32(byte_order)?
             .try_into()
             .map_err(|e| WkbError::General(format!("Invalid number of points: {}", e)))?;
 
-        let multipoint = Self {
+        let points_offset = num_points_offset + 4;
+        let mut multipoint = Self {
             buf,
             byte_order,
             num_points,
+            points_offset,
             dim,
-            has_srid,
         };
 
         let end_offset = multipoint.point_offset(num_points as u64);
         if end_offset > buf.len() as u64 {
             return Self::handle_invalid_buffer_length(end_offset, buf.len());
         }
+
+        multipoint.buf = &buf[0..end_offset as usize];
 
         Ok(multipoint)
     }
@@ -66,35 +70,24 @@ impl<'a> MultiPoint<'a> {
     }
 
     /// The number of bytes in this object, including any header
-    ///
-    /// Note that this is not the same as the length of the underlying buffer
+    #[inline]
     pub fn size(&self) -> u64 {
-        // - 1: byteOrder
-        // - 4: wkbType
-        // - 4: numPoints
-        // - Point::size() * self.num_points: the size of each Point for each point
-        let mut header = 1 + 4 + 4;
-        if self.has_srid {
-            header += 4;
-        }
-        header + ((1 + 4 + (self.dim.size() as u64 * 8)) * self.num_points as u64)
+        self.buf.len() as u64
     }
 
     /// The offset into this buffer of any given Point
     pub fn point_offset(&self, i: u64) -> u64 {
-        // - 1: byteOrder
-        // - 4: wkbType
-        // - 4: numPoints
-        let mut header = 1 + 4 + 4;
-        if self.has_srid {
-            header += 4;
-        }
-        header + ((1 + 4 + (self.dim.size() as u64 * 8)) * i)
+        self.points_offset + ((HEADER_BYTES + (self.dim.size() as u64 * 8)) * i)
     }
 
     /// The dimension of this MultiPoint
     pub fn dimension(&self) -> Dimension {
         self.dim
+    }
+
+    /// Get the underlying buffer of this MultiPoint
+    pub fn buf(&self) -> &'a [u8] {
+        self.buf
     }
 }
 
@@ -109,12 +102,8 @@ impl<'a> MultiPointTrait for MultiPoint<'a> {
     }
 
     unsafe fn point_unchecked(&self, i: usize) -> Self::InnerPointType<'_> {
-        Point::new(
-            self.buf,
-            self.byte_order,
-            self.point_offset(i as u64),
-            self.dim,
-        )
+        let offset = self.point_offset(i as u64);
+        Point::new(&self.buf[offset as usize..], self.byte_order, self.dim)
     }
 }
 
@@ -129,11 +118,7 @@ impl<'a> MultiPointTrait for &MultiPoint<'a> {
     }
 
     unsafe fn point_unchecked(&self, i: usize) -> Self::InnerPointType<'_> {
-        Point::new(
-            self.buf,
-            self.byte_order,
-            self.point_offset(i as u64),
-            self.dim,
-        )
+        let offset = self.point_offset(i as u64);
+        Point::new(&self.buf[offset as usize..], self.byte_order, self.dim)
     }
 }

--- a/src/reader/util.rs
+++ b/src/reader/util.rs
@@ -24,12 +24,12 @@ pub(crate) trait ReadBytesExt: byteorder::ReadBytesExt {
 impl<R: std::io::Read + ?Sized> ReadBytesExt for R {}
 
 /// Return `true` if this WKB item is EWKB and has an embedded SRID
-pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness, offset: u64) -> Result<bool, WkbError> {
+pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness) -> Result<bool, WkbError> {
     // Read geometry code to see if an SRID exists.
     let mut reader = Cursor::new(buf);
 
     // Skip 1-byte byte order that we already know
-    reader.set_position(1 + offset);
+    reader.set_position(1);
 
     let geometry_code = WkbGeometryCode::new(reader.read_u32(byte_order)?);
     Ok(geometry_code.has_srid())

--- a/src/test/ewkb.rs
+++ b/src/test/ewkb.rs
@@ -149,3 +149,62 @@ fn read_geometry_collection() {
         retour.to_geometry()
     );
 }
+
+fn test_ewkb_buf_with_trailing_data(g: &Geometry) {
+    let mut geos_geom = geometry_to_geos(g);
+    geos_geom.set_srid(1);
+
+    let mut wkb_writer = WKBWriter::new().unwrap();
+    wkb_writer.set_include_SRID(true);
+    let mut buf: Vec<u8> = wkb_writer.write_wkb(&geos_geom).unwrap().into();
+
+    let original_len = buf.len();
+    buf.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+
+    let wkb = read_wkb(&buf).unwrap();
+    let trimmed_buf = wkb.buf();
+    assert_eq!(trimmed_buf.len(), original_len);
+
+    let wkb2 = read_wkb(trimmed_buf).unwrap();
+    assert_eq!(*g, wkb2.to_geometry());
+}
+
+#[test]
+fn ewkb_point_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::Point(point_2d()));
+}
+
+#[test]
+fn ewkb_line_string_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::LineString(linestring_2d()));
+}
+
+#[test]
+fn ewkb_polygon_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::Polygon(polygon_2d()));
+}
+
+#[test]
+fn ewkb_polygon_with_interior_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::Polygon(polygon_2d_with_interior()));
+}
+
+#[test]
+fn ewkb_multi_point_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::MultiPoint(multi_point_2d()));
+}
+
+#[test]
+fn ewkb_multi_line_string_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::MultiLineString(multi_line_string_2d()));
+}
+
+#[test]
+fn ewkb_multi_polygon_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::MultiPolygon(multi_polygon_2d()));
+}
+
+#[test]
+fn ewkb_geometry_collection_buf_with_trailing_data() {
+    test_ewkb_buf_with_trailing_data(&Geometry::GeometryCollection(geometry_collection_2d()));
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] I ran cargo fmt
---

Fix #86

This is a follow-up of https://github.com/georust/wkb/pull/87. We refactored the code to remove the `buf` field from `Wkb` and add `buf` methods for geometry types to return sliced WKB buffers. There are also some refactorings to simplify various offset computations included in this PR.